### PR TITLE
Replace binary app icon assets with SVG

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,47 @@
-# todo
-get my life on track and do things
+# TaskLister
+
+TaskLister is a lightweight SwiftUI-powered iOS application that helps you capture tasks, organize them by urgency, and stay focused throughout the day. The repository ships with pure Swift source files and asset metadata so everything stays reviewable in plain text—no opaque Xcode project bundle required.
+
+## Features
+
+- ✅ **Quick capture** – Add new tasks with notes, optional due dates, and priority in a single form.
+- 📆 **Smart filtering** – Toggle between *All*, *Today*, *Upcoming*, and *Done* views to focus on what matters now.
+- 🔍 **Search** – Instantly find tasks by title or notes.
+- ✏️ **Inline editing** – Tap any row to update it, or swipe to complete and delete.
+- ☁️ **Persistent storage** – Tasks are saved locally as JSON so your list survives relaunches.
+- 🎨 **Custom design assets** – Includes simple accent color and a vector-based app icon that stays reviewable in plain text.
+
+## Project structure
+
+```
+TaskLister/
+├── Models/                  # Data models (Task, TaskPriority)
+├── Stores/                  # ObservableObject store with persistence
+├── Views/                   # SwiftUI screens and reusable components
+├── Utilities/               # Shared helpers (date formatting)
+├── Assets.xcassets/         # App icon + accent color definitions
+├── Preview Content/         # Preview assets for SwiftUI previews
+├── Info.plist               # Suggested app configuration values
+└── TaskListerApp.swift      # Main entry point wiring the views together
+```
+
+## Getting started in Xcode
+
+Because there is no `.xcodeproj` checked in, you can decide whether to embed the sources into an existing project or spin up a brand-new one. Here is a quick path to a fresh SwiftUI app:
+
+1. Open Xcode 15 (or newer) and create a new **App** project targeting iOS. Name it **TaskLister** (or anything you prefer).
+2. When the project opens, delete the boilerplate `ContentView.swift` and `YourAppNameApp.swift` files Xcode generated.
+3. Drag the entire `TaskLister` folder from this repository into the Project Navigator, making sure "Copy items if needed" is checked and the main app target is selected.
+4. If you want the sample accent color and SVG app icon metadata, also drag `TaskLister/Assets.xcassets` into your project's asset catalog.
+5. Build and run (⌘R). The SwiftUI hierarchy defined in `TaskListerApp.swift` will become the app's entry point automatically.
+
+> **Note:** The project targets iOS 16.0 and up because it relies on `NavigationStack` and other modern SwiftUI APIs.
+
+## Customization ideas
+
+- Hook the `TaskStore` up to CloudKit or Core Data for multi-device sync.
+- Extend the `Task` model with reminders using `UserNotifications`.
+- Add widgets or lock-screen complications that surface due-today tasks.
+- Group tasks into projects with color-coded sections.
+
+Feel free to tweak the UI and logic to fit your personal workflow—this repo is a solid foundation to build on.

--- a/TaskLister/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/TaskLister/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.282",
+          "green" : "0.396",
+          "red" : "0.984"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TaskLister/Assets.xcassets/AppIcon.appiconset/AppIcon.svg
+++ b/TaskLister/Assets.xcassets/AppIcon.appiconset/AppIcon.svg
@@ -1,0 +1,10 @@
+<svg width="1024" height="1024" viewBox="0 0 1024 1024" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="gradient" x1="170" y1="170" x2="854" y2="854" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#3A7BD5"/>
+      <stop offset="1" stop-color="#00D2FF"/>
+    </linearGradient>
+  </defs>
+  <rect x="64" y="64" width="896" height="896" rx="200" fill="url(#gradient)"/>
+  <path d="M420 686L272 538L342 468L420 546L684 282L754 352L420 686Z" fill="white"/>
+</svg>

--- a/TaskLister/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/TaskLister/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,18 @@
+{
+  "images" : [
+    {
+      "filename" : "AppIcon.svg",
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true,
+    "template-rendering-intent" : "original"
+  }
+}

--- a/TaskLister/Assets.xcassets/Contents.json
+++ b/TaskLister/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TaskLister/Info.plist
+++ b/TaskLister/Info.plist
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>$(DEVELOPMENT_LANGUAGE)</string>
+    <key>CFBundleExecutable</key>
+    <string>$(EXECUTABLE_NAME)</string>
+    <key>CFBundleIdentifier</key>
+    <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleName</key>
+    <string>$(PRODUCT_NAME)</string>
+    <key>CFBundlePackageType</key>
+    <string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+    <key>CFBundleShortVersionString</key>
+    <string>1.0</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+    <key>LSRequiresIPhoneOS</key>
+    <true/>
+    <key>UIApplicationSceneManifest</key>
+    <dict>
+        <key>UIApplicationSupportsMultipleScenes</key>
+        <true/>
+    </dict>
+    <key>UILaunchScreen</key>
+    <dict/>
+</dict>
+</plist>

--- a/TaskLister/Models/Task.swift
+++ b/TaskLister/Models/Task.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+enum TaskPriority: String, CaseIterable, Codable, Identifiable {
+    case low
+    case medium
+    case high
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .low:
+            return "Low"
+        case .medium:
+            return "Medium"
+        case .high:
+            return "High"
+        }
+    }
+}
+
+struct Task: Identifiable, Codable, Equatable {
+    var id: UUID = UUID()
+    var title: String
+    var notes: String = ""
+    var dueDate: Date?
+    var isCompleted: Bool = false
+    var priority: TaskPriority = .medium
+    var createdAt: Date = Date()
+
+    var isOverdue: Bool {
+        guard let dueDate else { return false }
+        return !isCompleted && dueDate < Calendar.current.startOfDay(for: Date())
+    }
+
+    var isDueToday: Bool {
+        guard let dueDate else { return false }
+        return Calendar.current.isDateInToday(dueDate)
+    }
+}
+
+extension Task {
+    static let sampleData: [Task] = [
+        Task(title: "Plan the week", notes: "Outline the top priorities for work and home.", dueDate: Calendar.current.date(byAdding: .day, value: 1, to: Date()), priority: .high),
+        Task(title: "Pick up groceries", notes: "Milk, eggs, spinach, oatmeal.", dueDate: Date(), priority: .medium),
+        Task(title: "Schedule dentist appointment", notes: "Call Dr. Patel's office.", dueDate: Calendar.current.date(byAdding: .day, value: 3, to: Date()), priority: .low),
+        Task(title: "Read 20 pages", notes: "Continue reading the productivity book.", dueDate: Calendar.current.date(byAdding: .day, value: -1, to: Date()), priority: .medium)
+    ]
+}

--- a/TaskLister/Preview Content/PreviewAssets.xcassets/Contents.json
+++ b/TaskLister/Preview Content/PreviewAssets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TaskLister/Stores/TaskStore.swift
+++ b/TaskLister/Stores/TaskStore.swift
@@ -1,0 +1,90 @@
+import Foundation
+import SwiftUI
+
+@MainActor
+final class TaskStore: ObservableObject {
+    @Published private(set) var tasks: [Task] = []
+
+    private let saveURL: URL
+    private let encoder: JSONEncoder
+    private let decoder: JSONDecoder
+
+    init(fileName: String = "tasks.json", inMemory: Bool = false) {
+        let directory: URL
+        if inMemory {
+            directory = FileManager.default.temporaryDirectory
+        } else {
+            directory = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first ?? FileManager.default.temporaryDirectory
+        }
+        self.saveURL = directory.appendingPathComponent(fileName)
+        self.encoder = JSONEncoder()
+        self.encoder.dateEncodingStrategy = .iso8601
+        self.decoder = JSONDecoder()
+        self.decoder.dateDecodingStrategy = .iso8601
+        load()
+    }
+
+    var upcomingTasks: [Task] {
+        tasks.filter { !$0.isCompleted }
+    }
+
+    var completedTasks: [Task] {
+        tasks.filter { $0.isCompleted }
+    }
+
+    func add(_ task: Task) {
+        tasks.append(task)
+        persist()
+    }
+
+    func update(_ task: Task) {
+        guard let index = tasks.firstIndex(where: { $0.id == task.id }) else { return }
+        tasks[index] = task
+        persist()
+    }
+
+    func toggleCompletion(for task: Task) {
+        guard let index = tasks.firstIndex(where: { $0.id == task.id }) else { return }
+        tasks[index].isCompleted.toggle()
+        persist()
+    }
+
+    func delete(at offsets: IndexSet) {
+        tasks.remove(atOffsets: offsets)
+        persist()
+    }
+
+    func delete(_ tasksToDelete: [Task]) {
+        let ids = Set(tasksToDelete.map(\.id))
+        tasks.removeAll { ids.contains($0.id) }
+        persist()
+    }
+
+    func move(from source: IndexSet, to destination: Int) {
+        tasks.move(fromOffsets: source, toOffset: destination)
+        persist()
+    }
+
+    private func load() {
+        do {
+            let data = try Data(contentsOf: saveURL)
+            tasks = try decoder.decode([Task].self, from: data)
+        } catch {
+            if FileManager.default.fileExists(atPath: saveURL.path) {
+                print("Failed to load tasks: \(error)")
+            } else {
+                tasks = Task.sampleData
+                persist()
+            }
+        }
+    }
+
+    private func persist() {
+        do {
+            let data = try encoder.encode(tasks)
+            try data.write(to: saveURL, options: [.atomic])
+        } catch {
+            print("Failed to save tasks: \(error)")
+        }
+    }
+}

--- a/TaskLister/TaskListerApp.swift
+++ b/TaskLister/TaskListerApp.swift
@@ -1,0 +1,13 @@
+import SwiftUI
+
+@main
+struct TaskListerApp: App {
+    @StateObject private var store = TaskStore()
+
+    var body: some Scene {
+        WindowGroup {
+            TaskListView()
+                .environmentObject(store)
+        }
+    }
+}

--- a/TaskLister/Utilities/DateFormatter+Extensions.swift
+++ b/TaskLister/Utilities/DateFormatter+Extensions.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+enum DateFormatterProvider {
+    static let taskDueDate: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .none
+        return formatter
+    }()
+}

--- a/TaskLister/Views/EmptyStateView.swift
+++ b/TaskLister/Views/EmptyStateView.swift
@@ -1,0 +1,38 @@
+import SwiftUI
+
+struct EmptyStateView: View {
+    let title: String
+    let message: String
+
+    var body: some View {
+        VStack(spacing: 16) {
+            Image(systemName: "checklist")
+                .font(.system(size: 50, weight: .light))
+                .foregroundColor(.accentColor)
+                .padding()
+                .background(Color.accentColor.opacity(0.1))
+                .clipShape(Circle())
+
+            VStack(spacing: 8) {
+                Text(title)
+                    .font(.title3.weight(.semibold))
+                Text(message)
+                    .font(.body)
+                    .multilineTextAlignment(.center)
+                    .foregroundColor(.secondary)
+                    .padding(.horizontal, 24)
+            }
+        }
+        .padding()
+        .frame(maxWidth: .infinity)
+        .accessibilityElement(children: .combine)
+    }
+}
+
+struct EmptyStateView_Previews: PreviewProvider {
+    static var previews: some View {
+        EmptyStateView(title: "No tasks", message: "Create your first task to see it here.")
+            .previewLayout(.sizeThatFits)
+            .padding()
+    }
+}

--- a/TaskLister/Views/TaskEditorView.swift
+++ b/TaskLister/Views/TaskEditorView.swift
@@ -1,0 +1,130 @@
+import SwiftUI
+
+struct TaskEditorView: View {
+    @Environment(\.dismiss) private var dismiss
+
+    private let task: Task?
+    private let onSave: (Task) -> Void
+
+    @State private var title: String
+    @State private var notes: String
+    @State private var hasDueDate: Bool
+    @State private var dueDate: Date
+    @State private var priority: TaskPriority
+    @State private var isCompleted: Bool
+    @FocusState private var focusedField: Field?
+
+    init(task: Task? = nil, onSave: @escaping (Task) -> Void) {
+        self.task = task
+        self.onSave = onSave
+
+        _title = State(initialValue: task?.title ?? "")
+        _notes = State(initialValue: task?.notes ?? "")
+        let initialDueDate = task?.dueDate ?? Calendar.current.date(byAdding: .day, value: 1, to: Date()) ?? Date()
+        _dueDate = State(initialValue: initialDueDate)
+        _hasDueDate = State(initialValue: task?.dueDate != nil)
+        _priority = State(initialValue: task?.priority ?? .medium)
+        _isCompleted = State(initialValue: task?.isCompleted ?? false)
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section(header: Text("Details")) {
+                    TextField("Title", text: $title)
+                        .focused($focusedField, equals: .title)
+                        .textInputAutocapitalization(.sentences)
+                        .disableAutocorrection(false)
+
+                    Picker("Priority", selection: $priority) {
+                        ForEach(TaskPriority.allCases) { priority in
+                            Text(priority.displayName).tag(priority)
+                        }
+                    }
+                    .pickerStyle(.segmented)
+                }
+
+                Section(header: Text("Due Date")) {
+                    Toggle("Set due date", isOn: $hasDueDate.animation())
+                    if hasDueDate {
+                        DatePicker("", selection: $dueDate, displayedComponents: [.date])
+                            .datePickerStyle(.graphical)
+                            .labelsHidden()
+                    }
+                }
+
+                Section(header: Text("Notes")) {
+                    ZStack(alignment: .topLeading) {
+                        if notes.isEmpty {
+                            Text("Add any extra context...")
+                                .foregroundColor(.secondary)
+                                .padding(.vertical, 8)
+                                .allowsHitTesting(false)
+                        }
+                        TextEditor(text: $notes)
+                            .frame(minHeight: 120)
+                            .focused($focusedField, equals: .notes)
+                    }
+                }
+
+                if task != nil {
+                    Section {
+                        Toggle("Mark as completed", isOn: $isCompleted)
+                    }
+                }
+            }
+            .navigationTitle(task == nil ? "New Task" : "Edit Task")
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Save") { saveTask() }
+                        .disabled(!canSave)
+                }
+            }
+            .onAppear {
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                    if task == nil {
+                        focusedField = .title
+                    }
+                }
+            }
+        }
+    }
+
+    private var canSave: Bool {
+        !title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    private func saveTask() {
+        var updatedTask = task ?? Task(title: title)
+        updatedTask.title = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        updatedTask.notes = notes.trimmingCharacters(in: .whitespacesAndNewlines)
+        updatedTask.dueDate = hasDueDate ? Calendar.current.startOfDay(for: dueDate) : nil
+        updatedTask.priority = priority
+        if task != nil {
+            updatedTask.isCompleted = isCompleted
+        } else {
+            updatedTask.isCompleted = false
+        }
+        onSave(updatedTask)
+        dismiss()
+    }
+
+    private enum Field {
+        case title
+        case notes
+    }
+}
+
+struct TaskEditorView_Previews: PreviewProvider {
+    static var previews: some View {
+        NavigationStack {
+            TaskEditorView(task: Task.sampleData.first!) { _ in }
+        }
+        NavigationStack {
+            TaskEditorView { _ in }
+        }
+    }
+}

--- a/TaskLister/Views/TaskFilterBar.swift
+++ b/TaskLister/Views/TaskFilterBar.swift
@@ -1,0 +1,23 @@
+import SwiftUI
+
+struct TaskFilterBar: View {
+    @Binding var selection: TaskFilter
+
+    var body: some View {
+        Picker("Filter", selection: $selection) {
+            ForEach(TaskFilter.allCases) { filter in
+                Text(filter.displayName).tag(filter)
+            }
+        }
+        .pickerStyle(.segmented)
+        .accessibilityLabel("Task filter")
+    }
+}
+
+struct TaskFilterBar_Previews: PreviewProvider {
+    static var previews: some View {
+        TaskFilterBar(selection: .constant(.all))
+            .padding()
+            .previewLayout(.sizeThatFits)
+    }
+}

--- a/TaskLister/Views/TaskListView.swift
+++ b/TaskLister/Views/TaskListView.swift
@@ -1,0 +1,219 @@
+import SwiftUI
+
+struct TaskListView: View {
+    @EnvironmentObject private var store: TaskStore
+    @State private var activeSheet: ActiveSheet?
+    @State private var searchText: String = ""
+    @State private var filter: TaskFilter = .all
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 0) {
+                TaskFilterBar(selection: $filter)
+                    .padding(.horizontal)
+                    .padding(.top, 12)
+
+                if filteredTasks.isEmpty {
+                    Spacer(minLength: 24)
+                    EmptyStateView(
+                        title: "No tasks to show",
+                        message: emptyStateMessage
+                    )
+                    Spacer()
+                } else {
+                    List {
+                        ForEach(filteredTasks) { task in
+                            TaskRowView(task: task, onToggleCompletion: {
+                                toggleCompletion(for: task)
+                            })
+                            .contentShape(Rectangle())
+                            .onTapGesture {
+                                activeSheet = .edit(task)
+                            }
+                            .swipeActions(edge: .leading, allowsFullSwipe: true) {
+                                Button {
+                                    toggleCompletion(for: task)
+                                } label: {
+                                    if task.isCompleted {
+                                        Label("Mark Open", systemImage: "arrow.uturn.backward.circle")
+                                    } else {
+                                        Label("Complete", systemImage: "checkmark.circle")
+                                    }
+                                }
+                                .tint(task.isCompleted ? .orange : .green)
+                            }
+                            .swipeActions(edge: .trailing) {
+                                Button(role: .destructive) {
+                                    store.delete([task])
+                                } label: {
+                                    Label("Delete", systemImage: "trash")
+                                }
+                            }
+                        }
+                        .onDelete(perform: deleteTasks)
+                        .onMove(perform: moveTasks)
+                    }
+                    .listStyle(.insetGrouped)
+                }
+            }
+            .navigationTitle("Task Lister")
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    EditButton()
+                        .disabled(!canReorder)
+                }
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button {
+                        activeSheet = .new
+                    } label: {
+                        Label("Add Task", systemImage: "plus")
+                    }
+                }
+            }
+            .searchable(text: $searchText, placement: .navigationBarDrawer(displayMode: .always))
+            .animation(.spring(response: 0.35, dampingFraction: 0.85), value: filteredTasks)
+        }
+        .sheet(item: $activeSheet, content: sheetContent)
+    }
+
+    private var filteredTasks: [Task] {
+        let trimmedQuery = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        let filtered = store.tasks.filter { task in
+            filter.allows(task: task) &&
+            (trimmedQuery.isEmpty || task.title.localizedCaseInsensitiveContains(trimmedQuery) || task.notes.localizedCaseInsensitiveContains(trimmedQuery))
+        }
+
+        return filtered.sorted { lhs, rhs in
+            switch (lhs.isCompleted, rhs.isCompleted) {
+            case (false, true):
+                return true
+            case (true, false):
+                return false
+            default:
+                break
+            }
+
+            let lhsDate = lhs.dueDate ?? Date.distantFuture
+            let rhsDate = rhs.dueDate ?? Date.distantFuture
+
+            if lhsDate != rhsDate {
+                return lhsDate < rhsDate
+            }
+
+            return lhs.createdAt < rhs.createdAt
+        }
+    }
+
+    private var emptyStateMessage: String {
+        switch filter {
+        case .all:
+            return "Add a task with the plus button to get started."
+        case .today:
+            return "You have nothing scheduled for today."
+        case .upcoming:
+            return "There are no upcoming tasks yet."
+        case .completed:
+            return "Complete a task to see it here."
+        }
+    }
+
+    private var canReorder: Bool {
+        filter == .all && searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    private func deleteTasks(at offsets: IndexSet) {
+        let tasksToDelete = offsets.compactMap { index -> Task? in
+            guard filteredTasks.indices.contains(index) else { return nil }
+            return filteredTasks[index]
+        }
+        store.delete(tasksToDelete)
+    }
+
+    private func moveTasks(from source: IndexSet, to destination: Int) {
+        guard canReorder else { return }
+        store.move(from: source, to: destination)
+    }
+
+    private func toggleCompletion(for task: Task) {
+        withAnimation {
+            store.toggleCompletion(for: task)
+        }
+    }
+
+    @ViewBuilder
+    private func sheetContent(for sheet: ActiveSheet) -> some View {
+        switch sheet {
+        case .new:
+            TaskEditorView { newTask in
+                store.add(newTask)
+            }
+        case .edit(let task):
+            TaskEditorView(task: task) { updatedTask in
+                store.update(updatedTask)
+            }
+        }
+    }
+}
+
+extension TaskListView {
+    enum ActiveSheet: Identifiable {
+        case new
+        case edit(Task)
+
+        var id: String {
+            switch self {
+            case .new:
+                return "new"
+            case .edit(let task):
+                return task.id.uuidString
+            }
+        }
+    }
+}
+
+enum TaskFilter: String, CaseIterable, Identifiable {
+    case all
+    case today
+    case upcoming
+    case completed
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .all:
+            return "All"
+        case .today:
+            return "Today"
+        case .upcoming:
+            return "Upcoming"
+        case .completed:
+            return "Done"
+        }
+    }
+
+    func allows(task: Task) -> Bool {
+        switch self {
+        case .all:
+            return true
+        case .today:
+            return task.isDueToday
+        case .upcoming:
+            if task.isCompleted {
+                return false
+            }
+            guard let dueDate = task.dueDate else { return true }
+            return dueDate >= Calendar.current.startOfDay(for: Date())
+        case .completed:
+            return task.isCompleted
+        }
+    }
+}
+
+struct TaskListView_Previews: PreviewProvider {
+    static var previews: some View {
+        TaskListView()
+            .environmentObject(TaskStore(inMemory: true))
+    }
+}

--- a/TaskLister/Views/TaskRowView.swift
+++ b/TaskLister/Views/TaskRowView.swift
@@ -1,0 +1,77 @@
+import SwiftUI
+
+struct TaskRowView: View {
+    let task: Task
+    var onToggleCompletion: () -> Void
+
+    var body: some View {
+        HStack(alignment: .center, spacing: 12) {
+            Button(action: onToggleCompletion) {
+                Image(systemName: task.isCompleted ? "checkmark.circle.fill" : "circle")
+                    .font(.title3.weight(.semibold))
+                    .foregroundStyle(task.isCompleted ? Color.accentColor : Color.secondary)
+                    .accessibilityLabel(task.isCompleted ? "Mark task as incomplete" : "Mark task as complete")
+            }
+            .buttonStyle(.plain)
+
+            VStack(alignment: .leading, spacing: 6) {
+                Text(task.title)
+                    .font(.headline)
+                    .foregroundStyle(task.isCompleted ? Color.secondary : Color.primary)
+                    .strikethrough(task.isCompleted, color: .secondary)
+                    .animation(.default, value: task.isCompleted)
+
+                if let dueDate = task.dueDate {
+                    Label(DateFormatterProvider.taskDueDate.string(from: dueDate), systemImage: task.isOverdue ? "calendar.badge.exclamationmark" : "calendar")
+                        .font(.caption)
+                        .foregroundStyle(task.isOverdue ? Color.red : Color.secondary)
+                        .strikethrough(task.isCompleted, color: .secondary)
+                        .animation(.default, value: task.isCompleted)
+                }
+
+                if !task.notes.isEmpty {
+                    Text(task.notes)
+                        .font(.subheadline)
+                        .foregroundStyle(Color.secondary)
+                        .lineLimit(2)
+                        .multilineTextAlignment(.leading)
+                }
+            }
+
+            Spacer()
+
+            Text(task.priority.displayName)
+                .font(.caption.weight(.semibold))
+                .padding(.vertical, 6)
+                .padding(.horizontal, 10)
+                .background(priorityColor.opacity(0.15))
+                .foregroundColor(priorityColor)
+                .clipShape(Capsule())
+                .accessibilityLabel("Priority \(task.priority.displayName)")
+        }
+        .padding(.vertical, 8)
+    }
+
+    private var priorityColor: Color {
+        switch task.priority {
+        case .low:
+            return Color.blue
+        case .medium:
+            return Color.orange
+        case .high:
+            return Color.red
+        }
+    }
+}
+
+struct TaskRowView_Previews: PreviewProvider {
+    static var previews: some View {
+        Group {
+            TaskRowView(task: Task.sampleData[0], onToggleCompletion: {})
+            TaskRowView(task: Task.sampleData[1], onToggleCompletion: {})
+                .preferredColorScheme(.dark)
+        }
+        .previewLayout(.sizeThatFits)
+        .padding()
+    }
+}


### PR DESCRIPTION
## Summary
- replace the PNG-based app icon set with a single text-based SVG asset so the repo stays diffable
- update the asset catalog metadata to point to the SVG icon and keep vector rendering enabled
- refresh the README to mention the SVG icon metadata when importing assets into Xcode

## Testing
- not run (iOS tooling unavailable)


------
https://chatgpt.com/codex/tasks/task_e_68c98cd885bc8331a4eaf4cf88af7273